### PR TITLE
Use of the Fira font (mozilla official one)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 @import url(font-awesome.min.css);
-@import "https://fonts.googleapis.com/css?family=Montserrat:700|Open+Sans:300,400|Pacifico";
+@import "https://fonts.googleapis.com/css?family=Montserrat:700|Open+Sans:300,400|Fira+Sans";
 
 /*
 	Intensify by TEMPLATED
@@ -2684,10 +2684,8 @@
 
 		#header .logo {
 			color: #f6755e;
-			font-family: "Pacifico", cursive;
+			font-family: 'Fira Sans', sans-serif;;
 			font-size: 2.5em;
-			letter-spacing: 2px;
-			margin-top: -5px;
 			text-decoration: none;
 			display: inline-block;
 		}


### PR DESCRIPTION
Font used on header: http://mozilla.github.io/Fira/

![captura de tela 2017-10-31 as 06 45 15](https://user-images.githubusercontent.com/1327488/32214762-125ff5da-be07-11e7-9a59-bb498e24f0c3.png)
